### PR TITLE
Update gitea version and mandate group

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-gitea_version: 1.9.5
+gitea_version: 1.11.3
 gitea_arch: amd64
 gitea_user: gitea
 gitea_database_backend: sqlite3

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,16 +4,22 @@
     name: git
     state: present
 
+- name: Ensure Gitea group exists
+  group:
+    name: "{{ gitea_user }}"
+    state: present
+
 - name: Creating the Gitea user
   user:
     name: "{{ gitea_user }}"
+    group: "{{ gitea_user }}"
     state: present
 
 - name: Downloading Gitea
   get_url:
     url: "https://dl.gitea.io/gitea/{{ gitea_version }}/gitea-{{ gitea_version }}-linux-{{ gitea_arch }}"
     dest: /usr/local/bin/gitea
-    mode: 0750
+    mode: 0770
     owner: "{{ gitea_user }}"
     group: "{{ gitea_user }}"
 
@@ -35,7 +41,7 @@
     path: /etc/gitea
     state: directory
     mode: 0770
-    owner: root
+    owner: "{{ gitea_user }}"
     group: "{{ gitea_user }}"
 
 - name: Creating the systemd service file

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
   get_url:
     url: "https://dl.gitea.io/gitea/{{ gitea_version }}/gitea-{{ gitea_version }}-linux-{{ gitea_arch }}"
     dest: /usr/local/bin/gitea
-    mode: 0770
+    mode: 0750
     owner: "{{ gitea_user }}"
     group: "{{ gitea_user }}"
 
@@ -41,7 +41,7 @@
     path: /etc/gitea
     state: directory
     mode: 0770
-    owner: "{{ gitea_user }}"
+    owner: root
     group: "{{ gitea_user }}"
 
 - name: Creating the systemd service file


### PR DESCRIPTION
This is mostly to fix an issue where Ansible will create the gitea user but not assign it to the "gitea" group. This occurs on distros like OpenSuse where users are added to the "users" group by default.

I've also bumped up the default gitea version to 1.11.3, since 1.9.5 is pretty far behind.